### PR TITLE
Fix room server login response

### DIFF
--- a/clidevice.py
+++ b/clidevice.py
@@ -69,6 +69,7 @@ class CLIDevice(BasicMesh):
             return
 
         while True:
+            await asyncio.sleep(5)
             await self.tx_advert(flood=True, priority=Dispatch.PRIORITY_SCHEDULED_ADVERT)
             self.last_flood_advert = time.time()
             logger.debug("Scheduled flood advert sent")
@@ -379,16 +380,9 @@ class CLIDevice(BasicMesh):
         #  * is_admin?
         #  * Permissions (various PERM_ACL_ options, currently 0; PERM_ACL_GUEST)
         #  * random number (4 bytes)
-        data = bytes([packet.MC_Packet.RESP_SERVER_LOGIN_OK, 0, 1 if dest.admin else 0, 0]) + randbytes(4)
-
-        if rx_packet.is_flood():
-            # Return a PATH packet with the response
-            timestamp = struct.pack("<L", unique_time())
-
-            response = packet.MC_Path_Out(self.me, dest, rx_packet.path, response=timestamp+data)
-        else:
-            # Packet came direct, no need to tell the sender how to get here
-            response = packet.MC_Response_Out(self.me, dest, data)
+        acl = 3 if dest.admin else 2
+        data = bytes([packet.MC_Packet.RESP_SERVER_LOGIN_OK, 0, 1 if dest.admin else 0, acl]) + randbytes(4)
+        response = packet.MC_Response_Out(self.me, dest, data, rx_packet.timestamp)
 
         await self.transmit_packet(response)
 


### PR DESCRIPTION
Two fixes to the ANON_REQ login response handler:

1. Echo the ANON_REQ timestamp back in the response so the companion firmware can match it to pending_req tag, enabling proper login handling for both flood and direct logins.

2. Set correct ACL permissions (PERM_ACL_READ_WRITE=2 for guest, PERM_ACL_ADMIN=3 for admin) instead of hardcoded 0, allowing clients to post messages to the room.

Also add a 5 second startup delay before the first flood advert to allow the companion radio interface time to connect, preventing the advert from being lost with 'Cannot send, companion radio not connected'.